### PR TITLE
refactor: streamline workspace and add search-lab verify mode

### DIFF
--- a/.claude/hooks/pre-commit-lint.sh
+++ b/.claude/hooks/pre-commit-lint.sh
@@ -5,6 +5,12 @@
 # Consume stdin (required — Claude Code pipes JSON on stdin)
 INPUT=$(cat)
 
+# Require jq for command filtering
+if ! command -v jq >/dev/null 2>&1; then
+    echo "pre-commit-lint.sh: jq is required but not installed" >&2
+    exit 2
+fi
+
 # Only run on git commit commands
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 case "$COMMAND" in
@@ -14,15 +20,19 @@ esac
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Check formatting
-if ! cargo fmt --all -- --check >/dev/null 2>&1; then
-    echo "cargo fmt --check failed. Run 'cargo fmt --all' first." >&2
+# Check formatting (forward diagnostics on failure)
+FMT_OUTPUT=$(cargo fmt --all -- --check 2>&1)
+if [ $? -ne 0 ]; then
+    echo "cargo fmt --check failed:" >&2
+    echo "$FMT_OUTPUT" >&2
     exit 2
 fi
 
-# Check clippy
-if ! cargo clippy --all-targets --all-features -- -D warnings >/dev/null 2>&1; then
-    echo "cargo clippy found warnings. Fix them before committing." >&2
+# Check clippy (forward diagnostics on failure)
+CLIPPY_OUTPUT=$(cargo clippy --all-targets --all-features -- -D warnings 2>&1)
+if [ $? -ne 0 ]; then
+    echo "cargo clippy found warnings:" >&2
+    echo "$CLIPPY_OUTPUT" >&2
     exit 2
 fi
 

--- a/.claude/hooks/pre-commit-lint.sh
+++ b/.claude/hooks/pre-commit-lint.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 # PreToolUse hook: blocks git commit if cargo fmt or clippy fail.
-# Follows the official Claude Code hooks pattern from code.claude.com/docs/en/hooks
+# Only activates on git commit commands — skips everything else.
 
 # Consume stdin (required — Claude Code pipes JSON on stdin)
 INPUT=$(cat)
+
+# Only run on git commit commands
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+case "$COMMAND" in
+    git\ commit*) ;;
+    *) exit 0 ;;
+esac
 
 cd "$CLAUDE_PROJECT_DIR"
 

--- a/.claude/hooks/pre-commit-lint.sh
+++ b/.claude/hooks/pre-commit-lint.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
-# Pre-commit hook: blocks git commit if cargo fmt or clippy fail.
-# Runs on PreToolUse when the Bash tool is about to execute a git commit.
-set -euo pipefail
+# PreToolUse hook: blocks git commit if cargo fmt or clippy fail.
+# Follows the official Claude Code hooks pattern from code.claude.com/docs/en/hooks
 
-cd "$(git rev-parse --show-toplevel 2>/dev/null || echo "$CLAUDE_PROJECT_DIR")"
+# Consume stdin (required — Claude Code pipes JSON on stdin)
+INPUT=$(cat)
+
+cd "$CLAUDE_PROJECT_DIR"
 
 # Check formatting
-if ! cargo fmt --all -- --check 2>/dev/null; then
-    echo "BLOCKED: cargo fmt --check failed. Run 'cargo fmt --all' first." >&2
+if ! cargo fmt --all -- --check >/dev/null 2>&1; then
+    echo "cargo fmt --check failed. Run 'cargo fmt --all' first." >&2
     exit 2
 fi
 
 # Check clippy
-if ! cargo clippy --all-targets --all-features -- -D warnings 2>/dev/null; then
-    echo "BLOCKED: cargo clippy found warnings. Fix them before committing." >&2
+if ! cargo clippy --all-targets --all-features -- -D warnings >/dev/null 2>&1; then
+    echo "cargo clippy found warnings. Fix them before committing." >&2
     exit 2
 fi
 

--- a/.claude/hooks/stop-fmt.sh
+++ b/.claude/hooks/stop-fmt.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
 # Stop hook: runs cargo fmt once per turn after Claude finishes responding.
-# Follows the official Claude Code hooks pattern from code.claude.com/docs/en/hooks
 
 # Consume stdin (required — Claude Code pipes JSON on stdin)
-INPUT=$(cat)
-
-# Prevent infinite loop: if this is a re-fire, allow stop
-if echo "$INPUT" | jq -re '.stop_hook_active' >/dev/null 2>&1; then
-    exit 0
-fi
+cat > /dev/null
 
 cd "$CLAUDE_PROJECT_DIR"
 cargo fmt --all >/dev/null 2>&1 || true

--- a/.claude/hooks/stop-fmt.sh
+++ b/.claude/hooks/stop-fmt.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
-# Stop hook: runs cargo fmt once per turn, after Claude finishes responding.
-# This avoids the PostToolUse cache-staleness problem where formatting a file
-# mid-turn causes Claude to see stale content on its next read.
-cd "$(git rev-parse --show-toplevel 2>/dev/null || echo "$CLAUDE_PROJECT_DIR")"
-cargo fmt --all 2>/dev/null || true
+# Stop hook: runs cargo fmt once per turn after Claude finishes responding.
+# Follows the official Claude Code hooks pattern from code.claude.com/docs/en/hooks
+
+# Consume stdin (required — Claude Code pipes JSON on stdin)
+INPUT=$(cat)
+
+# Prevent infinite loop: if this is a re-fire, allow stop
+if echo "$INPUT" | jq -re '.stop_hook_active' >/dev/null 2>&1; then
+    exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+cargo fmt --all >/dev/null 2>&1 || true
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,6 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit *)",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-lint.sh",
             "timeout": 120
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,23 +6,20 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/pre-commit-lint.sh",
             "if": "Bash(git commit *)",
-            "timeout": 120,
-            "statusMessage": "Running cargo fmt check + clippy..."
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-commit-lint.sh",
+            "timeout": 120
           }
         ]
       }
     ],
     "Stop": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/stop-fmt.sh",
-            "timeout": 30,
-            "statusMessage": "Formatting Rust code..."
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/stop-fmt.sh",
+            "timeout": 30
           }
         ]
       }

--- a/crates/erdos396/Cargo.toml
+++ b/crates/erdos396/Cargo.toml
@@ -24,7 +24,7 @@ num_cpus = "1.16"
 # Small vector optimization
 smallvec = "1.13"
 
-# CLI (used by library checkpoint/search config types)
+# CLI (used by archived binaries; not consumed by the library itself)
 clap = { version = "4.4", features = ["derive"] }
 
 # Serialization for checkpoints

--- a/crates/erdos396/Cargo.toml
+++ b/crates/erdos396/Cargo.toml
@@ -3,7 +3,7 @@ name = "erdos396"
 version = "1.0.0"
 edition = "2021"
 authors = ["Erdős 396 Research Team"]
-description = "High-performance search for Erdős Problem #396 witnesses via Governor Set analysis"
+description = "Core mathematical library for Erdős Problem #396 — governor set analysis, prime sieves, and witness verification"
 license = "MIT"
 repository = "https://github.com/jdehorty/erdos396"
 keywords = ["number-theory", "erdos", "combinatorics", "parallel"]
@@ -13,37 +13,8 @@ categories = ["mathematics", "science"]
 name = "erdos396"
 path = "src/lib.rs"
 
-[[bin]]
-name = "erdos396"
-path = "src/main.rs"
-
-[[bin]]
-name = "verify"
-path = "src/bin/verify.rs"
-
-[[bin]]
-name = "validate"
-path = "src/bin/validate.rs"
-
-[[bin]]
-name = "audit_runs"
-path = "src/bin/audit_runs.rs"
-
-[[bin]]
-name = "build_run_corpus"
-path = "src/bin/build_run_corpus.rs"
-
-[[bin]]
-name = "classify_run_windows"
-path = "src/bin/classify_run_windows.rs"
-
-[[bin]]
-name = "query_run_windows"
-path = "src/bin/query_run_windows.rs"
-
-[[bin]]
-name = "analyze_false_positives"
-path = "src/bin/analyze_false_positives.rs"
+# Binaries have been archived to the archive/erdos396-monolith branch.
+# The library is retained as a dependency for carry-diagnostic and tests.
 
 [dependencies]
 # Parallelism
@@ -53,14 +24,14 @@ num_cpus = "1.16"
 # Small vector optimization
 smallvec = "1.13"
 
-# CLI
+# CLI (used by library checkpoint/search config types)
 clap = { version = "4.4", features = ["derive"] }
 
 # Serialization for checkpoints
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-# Columnar storage
+# Columnar storage (used by run_collection module)
 arrow = "54.2"
 parquet = { version = "54.2", features = ["arrow"] }
 walkdir = "2.5"
@@ -79,5 +50,5 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 anyhow = "1.0"
 
-# Temp dirs (used by bench mode to avoid polluting real output dir)
+# Temp dirs
 tempfile = "3.10"

--- a/crates/search-lab/Cargo.toml
+++ b/crates/search-lab/Cargo.toml
@@ -2,5 +2,5 @@
 name = "erdos396-search-lab"
 version = "0.1.0"
 edition = "2021"
-description = "Minimal, bare-bones witness search for Erdős #396 — a lightweight testing ground for search algorithm improvements"
+description = "High-performance witness search and verification for Erdős Problem #396"
 license = "MIT"

--- a/crates/search-lab/src/main.rs
+++ b/crates/search-lab/src/main.rs
@@ -758,6 +758,14 @@ const KNOWN_WITNESSES: &[(u64, u64)] = &[
 
 /// Verify a single (k, n) witness with a detailed per-prime report.
 fn verify_witness(k: u64, n: u64, prime_data: &[PrimeData]) -> bool {
+    if k == 0 || n <= k {
+        eprintln!(
+            "Error: --verify requires k >= 1 and n > k (got k={}, n={})",
+            k, n
+        );
+        return false;
+    }
+
     let two_k = 2 * k;
     let two_n = 2 * n;
     let mut all_pass = true;

--- a/crates/search-lab/src/main.rs
+++ b/crates/search-lab/src/main.rs
@@ -753,7 +753,7 @@ const KNOWN_WITNESSES: &[(u64, u64)] = &[
 ];
 
 // ---------------------------------------------------------------------------
-// Verify — detailed witness verification using Legendre's formula
+// Verify — detailed witness verification
 // ---------------------------------------------------------------------------
 
 /// Verify a single (k, n) witness with a detailed per-prime report.
@@ -773,7 +773,13 @@ fn verify_witness(k: u64, n: u64, prime_data: &[PrimeData]) -> bool {
     println!("Verifying k={}, n={}", k, n);
     println!();
 
-    // p=2: popcount-based check
+    // p=2: v_2(C(2n,n)) >= v_2(n!/(n-k-1)!) via Kummer/popcount.
+    // Demand = v_2(n!/(n-k-1)!) = (popcount(n-k-1) - popcount(n) + k+1).
+    // Wrapping arithmetic is correct here: the formula is evaluated mod 2^64
+    // and the final comparison supply >= demand holds iff the true (signed)
+    // demand is non-negative and at most supply. When the true value is
+    // negative, wrapping produces a large u64 that fails supply >= demand,
+    // giving the correct PASS result.
     {
         let supply = n.count_ones() as u64;
         let nk1_ones = (n - k - 1).count_ones() as u64;
@@ -920,10 +926,19 @@ fn verify_witness(k: u64, n: u64, prime_data: &[PrimeData]) -> bool {
 }
 
 /// Verify all known OEIS A375077 witnesses.
+/// Uses exact_check (the search-path function) for speed rather than the
+/// verbose verify_witness. This is intentional: batch mode prints one line
+/// per witness, not a full per-prime report.
 fn verify_all_known(prime_data: &[PrimeData]) -> bool {
     println!("Verifying all known OEIS A375077 witnesses...\n");
     let mut all_pass = true;
     for &(k, n) in KNOWN_WITNESSES {
+        debug_assert!(
+            k > 0 && n > k,
+            "KNOWN_WITNESSES entry ({}, {}) violates n > k",
+            k,
+            n
+        );
         let pass = exact_check(n, k, prime_data);
         let status = if pass { "PASS" } else { "FAIL" };
         println!("  k={:2}, n={:>20}: {}", k, n, status);
@@ -997,11 +1012,20 @@ fn main() {
                 bench_secs = args[i].parse().unwrap();
             }
             "--verify" => {
-                // --verify K N
+                if i + 2 >= args.len() {
+                    eprintln!("Error: --verify requires two arguments: --verify <k> <n>");
+                    std::process::exit(1);
+                }
                 i += 1;
-                verify_k = Some(args[i].parse().unwrap());
+                verify_k = Some(args[i].parse().unwrap_or_else(|e| {
+                    eprintln!("Error: invalid k value '{}': {}", args[i], e);
+                    std::process::exit(1);
+                }));
                 i += 1;
-                verify_n = Some(args[i].parse().unwrap());
+                verify_n = Some(args[i].parse().unwrap_or_else(|e| {
+                    eprintln!("Error: invalid n value '{}': {}", args[i], e);
+                    std::process::exit(1);
+                }));
             }
             "--verify-known" => {
                 verify_known = true;
@@ -1020,7 +1044,9 @@ fn main() {
                 eprintln!("  --bench <secs>      sieve-only benchmark for <secs> seconds");
                 eprintln!();
                 eprintln!("Verify:");
-                eprintln!("  --verify <k> <n>    verify a single witness with detailed report");
+                eprintln!(
+                    "  --verify <k> <n>    verify a single (k, n) witness (requires k >= 1, n > k)"
+                );
                 eprintln!("  --verify-known      verify all 13 known OEIS A375077 witnesses");
                 std::process::exit(1);
             }

--- a/crates/search-lab/src/main.rs
+++ b/crates/search-lab/src/main.rs
@@ -734,6 +734,208 @@ fn solve(
 }
 
 // ---------------------------------------------------------------------------
+// Known witnesses — OEIS A375077
+// ---------------------------------------------------------------------------
+const KNOWN_WITNESSES: &[(u64, u64)] = &[
+    (1, 2),
+    (2, 2_480),
+    (3, 8_178),
+    (4, 45_153),
+    (5, 3_648_841),
+    (6, 7_979_090),
+    (7, 101_130_029),
+    (8, 339_949_252),
+    (9, 1_019_547_844),
+    (10, 17_609_764_994),
+    (11, 1_070_858_041_585),
+    (12, 5_048_891_644_646),
+    (13, 18_253_129_921_842),
+];
+
+// ---------------------------------------------------------------------------
+// Verify — detailed witness verification using Legendre's formula
+// ---------------------------------------------------------------------------
+
+/// Verify a single (k, n) witness with a detailed per-prime report.
+fn verify_witness(k: u64, n: u64, prime_data: &[PrimeData]) -> bool {
+    let two_k = 2 * k;
+    let two_n = 2 * n;
+    let mut all_pass = true;
+
+    println!("Verifying k={}, n={}", k, n);
+    println!();
+
+    // p=2: popcount-based check
+    {
+        let supply = n.count_ones() as u64;
+        let nk1_ones = (n - k - 1).count_ones() as u64;
+        let demand = nk1_ones.wrapping_sub(supply).wrapping_add(k + 1);
+        let pass = supply >= demand;
+        let status = if pass { "PASS" } else { "FAIL" };
+        println!(
+            "  p=2:  supply(popcount)={}, demand={} [{}]",
+            supply, demand, status
+        );
+        if !pass {
+            all_pass = false;
+        }
+    }
+
+    // Barrier primes p in (2, 2k]
+    for pd in prime_data {
+        let p = pd.p;
+        if p == 2 {
+            continue;
+        }
+        if p > two_k {
+            break;
+        }
+        let nk1 = n - k - 1;
+        let (mut demand, mut supply, mut pw) = (0u64, 0u64, p);
+        loop {
+            let vn = n / pw;
+            demand += vn - nk1 / pw;
+            supply += two_n / pw - (vn << 1);
+            if pw > two_n / p {
+                break;
+            }
+            pw *= p;
+        }
+        let pass = demand <= supply;
+        let status = if pass { "PASS" } else { "FAIL" };
+        println!(
+            "  p={}: supply={}, demand={} [{}]",
+            p, supply, demand, status
+        );
+        if !pass {
+            all_pass = false;
+        }
+    }
+
+    // Per-element large prime check
+    let mut large_prime_ok = true;
+    for i in 0..=k {
+        let ni = n - i;
+        let mut temp = ni;
+        temp >>= temp.trailing_zeros();
+
+        for pd in prime_data {
+            let p = pd.p;
+            if p == 2 {
+                continue;
+            }
+            if p <= two_k {
+                let mut q = temp.wrapping_mul(pd.inv_p);
+                while q <= pd.max_quot {
+                    temp = q;
+                    q = temp.wrapping_mul(pd.inv_p);
+                }
+                continue;
+            }
+
+            if p * p > temp {
+                if temp > two_k {
+                    let p_val = temp;
+                    let mut nu_prod = 1u64;
+                    let mut t2 = ni / p_val;
+                    while t2 > 0 && t2 % p_val == 0 {
+                        nu_prod += 1;
+                        t2 /= p_val;
+                    }
+                    let mut nu_comb = 0u64;
+                    let mut power = p_val;
+                    loop {
+                        let v_n = n / power;
+                        nu_comb += two_n / power - 2 * v_n;
+                        if power > two_n / p_val {
+                            break;
+                        }
+                        power *= p_val;
+                    }
+                    if nu_prod > nu_comb {
+                        println!(
+                            "  n-{}={}: large prime p={}, demand={} > supply={} [FAIL]",
+                            i, ni, p_val, nu_prod, nu_comb
+                        );
+                        large_prime_ok = false;
+                    }
+                }
+                break;
+            }
+
+            let q = temp.wrapping_mul(pd.inv_p);
+            if q <= pd.max_quot {
+                let mut nu_prod = 0u64;
+                let mut q2 = q;
+                loop {
+                    nu_prod += 1;
+                    temp = q2;
+                    q2 = temp.wrapping_mul(pd.inv_p);
+                    if q2 > pd.max_quot {
+                        break;
+                    }
+                }
+                let mut nu_comb = 0u64;
+                let mut power = p;
+                loop {
+                    let v_n = n / power;
+                    nu_comb += two_n / power - 2 * v_n;
+                    if power > two_n / p {
+                        break;
+                    }
+                    power *= p;
+                }
+                if nu_prod > nu_comb {
+                    println!(
+                        "  n-{}={}: prime p={}, demand={} > supply={} [FAIL]",
+                        i, ni, p, nu_prod, nu_comb
+                    );
+                    large_prime_ok = false;
+                }
+            }
+        }
+    }
+
+    if large_prime_ok {
+        println!("  large primes: all block terms pass [PASS]");
+    }
+    all_pass = all_pass && large_prime_ok;
+
+    println!();
+    if all_pass {
+        println!("RESULT: k={}, n={} is a VALID witness", k, n);
+    } else {
+        println!("RESULT: k={}, n={} is NOT a valid witness", k, n);
+    }
+
+    all_pass
+}
+
+/// Verify all known OEIS A375077 witnesses.
+fn verify_all_known(prime_data: &[PrimeData]) -> bool {
+    println!("Verifying all known OEIS A375077 witnesses...\n");
+    let mut all_pass = true;
+    for &(k, n) in KNOWN_WITNESSES {
+        let pass = exact_check(n, k, prime_data);
+        let status = if pass { "PASS" } else { "FAIL" };
+        println!("  k={:2}, n={:>20}: {}", k, n, status);
+        if !pass {
+            all_pass = false;
+        }
+    }
+    println!();
+    if all_pass {
+        println!(
+            "All {} known witnesses verified successfully.",
+            KNOWN_WITNESSES.len()
+        );
+    } else {
+        println!("SOME WITNESSES FAILED VERIFICATION.");
+    }
+    all_pass
+}
+
+// ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
 fn main() {
@@ -745,6 +947,9 @@ fn main() {
     let mut run_log: u64 = 10;
     let mut progress = false;
     let mut bench_secs: f64 = 0.0;
+    let mut verify_k: Option<u64> = None;
+    let mut verify_n: Option<u64> = None;
+    let mut verify_known = false;
     let mut n_threads = std::thread::available_parallelism()
         .map(|n| n.get() as u32)
         .unwrap_or(1);
@@ -783,15 +988,58 @@ fn main() {
                 i += 1;
                 bench_secs = args[i].parse().unwrap();
             }
+            "--verify" => {
+                // --verify K N
+                i += 1;
+                verify_k = Some(args[i].parse().unwrap());
+                i += 1;
+                verify_n = Some(args[i].parse().unwrap());
+            }
+            "--verify-known" => {
+                verify_known = true;
+            }
             _ => {
-                eprintln!(
-                    "Usage: {} [-k K] [--start N] [--end N] [--kmax KMAX] [--threads T] [--run-log N] [--progress] [--bench SECS]",
-                    args[0]
-                );
+                eprintln!("Usage: {} [options]", args[0]);
+                eprintln!();
+                eprintln!("Search:");
+                eprintln!("  -k <k>              starting k value (default: 1)");
+                eprintln!("  --start <n>         search range start (default: 1)");
+                eprintln!("  --end <n>           search range end (default: inf)");
+                eprintln!("  --kmax <k>          maximum k value (default: 20)");
+                eprintln!("  --threads <t>       worker thread count (default: all cores)");
+                eprintln!("  --run-log <n>       run-length logging threshold (default: 10)");
+                eprintln!("  --progress          print throughput stats to stderr");
+                eprintln!("  --bench <secs>      sieve-only benchmark for <secs> seconds");
+                eprintln!();
+                eprintln!("Verify:");
+                eprintln!("  --verify <k> <n>    verify a single witness with detailed report");
+                eprintln!("  --verify-known      verify all 13 known OEIS A375077 witnesses");
                 std::process::exit(1);
             }
         }
         i += 1;
+    }
+
+    // Handle verify modes early — no search needed
+    if verify_known || verify_k.is_some() {
+        let t0 = Instant::now();
+        let primes = sieve_primes(200_000_000);
+        let prime_data = build_prime_data(&primes);
+        eprintln!(
+            "# primes: {} in {:.3}s",
+            primes.len(),
+            t0.elapsed().as_secs_f64()
+        );
+
+        if verify_known {
+            let pass = verify_all_known(&prime_data);
+            std::process::exit(if pass { 0 } else { 1 });
+        }
+
+        if let (Some(k), Some(n)) = (verify_k, verify_n) {
+            let pass = verify_witness(k, n, &prime_data);
+            std::process::exit(if pass { 0 } else { 1 });
+        }
     }
 
     let end_str = if end_l == u64::MAX {


### PR DESCRIPTION
## Summary

- **erdos396 crate:** Strip down to library-only — remove all 7 binary targets. The library is retained as a dependency for carry-diagnostic. All binaries and analysis tooling are preserved on the `archive/erdos396-monolith` branch.
- **search-lab:** Add `--verify K N` for detailed per-prime witness verification and `--verify-known` for batch verification of all 13 known OEIS A375077 witnesses.

## New search-lab modes

```bash
# Detailed single-witness verification
erdos396-search-lab --verify 8 339949252

# Batch verify all known witnesses
erdos396-search-lab --verify-known
```

## Test plan

- [x] `cargo test --all` — 138 tests pass (80 erdos396 + 34 carry-diagnostic + 15 search-lab + 9 other)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `--verify-known` confirms all 13 known witnesses
- [x] `--verify 8 339949252` produces correct per-prime report
- [x] `--verify 8 339949251` correctly rejects with detailed failure